### PR TITLE
Fix restore path check

### DIFF
--- a/cli/CommandCenter.cs
+++ b/cli/CommandCenter.cs
@@ -876,7 +876,7 @@ namespace MemoriaNote.Cli
 
                 if (outputDir != null)
                 {
-                    if (Directory.Exists(outputDir))
+                    if (!Directory.Exists(outputDir))
                     {
                         Console.Error.WriteLine("Error: No such directory");
                         return -1;

--- a/core/Configuration.cs
+++ b/core/Configuration.cs
@@ -36,7 +36,7 @@ namespace MemoriaNote
 
         /// <summary>
         /// Represents the Logging settings for the application
-        /// Inherits from ConfigurationBase and is marked with DataContract attribute to indicate serializability
+        /// Inherits from ConfigurationBase and is marked with DataContract attribute to indicate it is serializable
         /// </summary>
         [DataMember]
         [Reactive]
@@ -65,7 +65,7 @@ namespace MemoriaNote
 
         /// <summary>
         /// Represents the Search settings for the application 
-        /// Inherits from ConfigurationBase and is marked with DataContract attribute to indicate serializability
+        /// Inherits from ConfigurationBase and is marked with DataContract attribute to indicate it is serializable
         /// </summary>
         [DataMember]
         [Reactive]

--- a/cspell.json
+++ b/cspell.json
@@ -14,7 +14,9 @@
         "serilog",
         "Subviews",
         "Taskpool",
-        "ustring"
+        "ustring",
+        "Autoincrement",
+        "NOCASE"
     ],
     "ignoreWords": [],
     "import": []


### PR DESCRIPTION
## Summary
- fix restore command directory existence check
- adjust comments in `Configuration` and update cspell dictionary

## Testing
- `dotnet build` in `core`
- `dotnet build` in `cli`
- `npx -y cspell --config cspell.json "**/*.cs"`

------
https://chatgpt.com/codex/tasks/task_e_683f7ad4f61083229e2c0d6854f96c78